### PR TITLE
Enable search of certificates in PEM files for directory Certificate store

### DIFF
--- a/Applications/ConsoleReferenceServer/PEMReaderCustom.cs
+++ b/Applications/ConsoleReferenceServer/PEMReaderCustom.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+#if NETSTANDARD2_1 || NET5_0_OR_GREATER
+
+namespace Quickstarts
+{
+    public static class PEMReaderCustom
+    {
+        #region Public Methods
+        /// <summary>
+        /// Import multiple X509 certificates from PEM data.
+        /// Supports a maximum of 99 certificates in the PEM data.
+        /// </summary>
+        /// <param name="pemDataBlob">The PEM datablob as byte array.</param>
+        /// <returns>The certificates.</returns>
+        public static X509Certificate2Collection ImportX509CertificatesFromPEM(
+            ReadOnlySpan<byte> pemDataBlob)
+        {
+            var certificates = new X509Certificate2Collection();
+            string label = "CERTIFICATE";
+            try
+            {
+                string pemText = Encoding.UTF8.GetString(pemDataBlob);
+                int count = 0;
+                int endIndex = 0;
+                while (endIndex > -1 && count < 99)
+                {
+                    count++;
+                    string beginlabel = $"-----BEGIN {label}-----";
+                    int beginIndex = pemText.IndexOf(beginlabel, StringComparison.Ordinal);
+                    if (beginIndex < 0)
+                    {
+                        return certificates;
+                    }
+                    string endlabel = $"-----END {label}-----";
+                    endIndex = pemText.IndexOf(endlabel, StringComparison.Ordinal);
+                    beginIndex += beginlabel.Length;
+                    if (endIndex < 0 || endIndex <= beginIndex)
+                    {
+                        return certificates;
+                    }
+                    var pemCertificateContent = pemText.Substring(beginIndex, endIndex - beginIndex);
+                    Span<byte> pemCertificateDecoded = new Span<byte>(new byte[pemCertificateContent.Length]);
+                    if (Convert.TryFromBase64Chars(pemCertificateContent, pemCertificateDecoded, out var bytesWritten))
+                    {
+#if NET6_0_OR_GREATER
+                        certificates.Add(X509CertificateLoader.LoadCertificate(pemCertificateDecoded));
+#else
+                        certificates.Add(X509CertificateLoader.LoadCertificate(pemCertificateDecoded.ToArray()));
+#endif
+                    }
+
+                    pemText = pemText.Substring(endIndex + endlabel.Length);
+                }
+            }
+            catch (CryptographicException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new CryptographicException("Failed to decode the PEM encoded Certificates.", ex);
+            }
+            return certificates;
+        }
+    }
+    #endregion
+}
+#endif

--- a/Applications/ConsoleReferenceServer/Program.cs
+++ b/Applications/ConsoleReferenceServer/Program.cs
@@ -91,6 +91,8 @@ namespace Quickstarts.ReferenceServer
                     output = new LogWriter();
                 }
 
+                CertificateStoreType.RegisterCertificateStoreType(DirectoryPEMSupportCertificateStoreType.StoreName, new DirectoryPEMSupportCertificateStoreType());
+
                 // create the UA server
                 var server = new UAServer<ReferenceServer>(output) {
                     AutoAccept = autoAccept,

--- a/Applications/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
+++ b/Applications/ConsoleReferenceServer/Quickstarts.ReferenceServer.Config.xml
@@ -53,13 +53,13 @@
 
     <!-- Where the issuer certificate are stored (certificate authorities) -->
     <TrustedIssuerCertificates>
-      <StoreType>Directory</StoreType>
+      <StoreType>DirectoryPEMSupport</StoreType>
       <StorePath>%LocalApplicationData%/OPC Foundation/pki/issuer</StorePath>
     </TrustedIssuerCertificates>
 
     <!-- Where the trust list is stored -->
     <TrustedPeerCertificates>
-      <StoreType>Directory</StoreType>
+      <StoreType>DirectoryPEMSupport</StoreType>
       <StorePath>%LocalApplicationData%/OPC Foundation/pki/trusted</StorePath>
     </TrustedPeerCertificates>
 

--- a/Libraries/Opc.Ua.Security.Certificates/PEM/PEMReader.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/PEM/PEMReader.cs
@@ -33,6 +33,7 @@ using System;
 using System.Security.Cryptography;
 using System.IO;
 using System.Text;
+using System.Security.Cryptography.X509Certificates;
 
 namespace Opc.Ua.Security.Certificates
 {
@@ -41,7 +42,65 @@ namespace Opc.Ua.Security.Certificates
     /// </summary>
     public static class PEMReader
     {
-#region Public Methods
+        #region Public Methods
+        /// <summary>
+        /// Import multiple X509 certificates from PEM data.
+        /// Supports a maximum of 99 certificates in the PEM data.
+        /// </summary>
+        /// <param name="pemDataBlob">The PEM datablob as byte array.</param>
+        /// <returns>The certificates.</returns>
+        public static X509Certificate2Collection ImportX509CertificatesFromPEM(
+            ReadOnlySpan<byte> pemDataBlob)
+        {
+            var certificates = new X509Certificate2Collection();
+            string label = "CERTIFICATE";
+            try
+            {
+                string pemText = Encoding.UTF8.GetString(pemDataBlob);
+                int count = 0;
+                int endIndex = 0;
+                while (endIndex > -1 && count < 99)
+                {
+                    count++;
+                    string beginlabel = $"-----BEGIN {label}-----";
+                    int beginIndex = pemText.IndexOf(beginlabel, StringComparison.Ordinal);
+                    if (beginIndex < 0)
+                    {
+                        return certificates;
+                    }
+                    string endlabel = $"-----END {label}-----";
+                    endIndex = pemText.IndexOf(endlabel, StringComparison.Ordinal);
+                    beginIndex += beginlabel.Length;
+                    if (endIndex < 0 || endIndex <= beginIndex)
+                    {
+                        return certificates;
+                    }
+                    var pemCertificateContent = pemText.Substring(beginIndex, endIndex - beginIndex);
+                    Span<byte> pemCertificateDecoded = new Span<byte>(new byte[pemCertificateContent.Length]);
+                    if (Convert.TryFromBase64Chars(pemCertificateContent, pemCertificateDecoded, out var bytesWritten))
+                    {
+#if NET6_0_OR_GREATER
+                        certificates.Add(X509CertificateLoader.LoadCertificate(pemCertificateDecoded));
+#else
+                        certificates.Add(new X509Certificate2(pemCertificateDecoded.ToArray()));
+#endif
+                    }
+
+                    pemText = pemText.Substring(endIndex + endlabel.Length);
+                }
+            }
+            catch (CryptographicException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new CryptographicException("Failed to decode the PEM encoded Certificates.", ex);
+            }
+            return certificates;
+        }
+
+
         /// <summary>
         /// Import a PKCS#8 private key or RSA private key from PEM.
         /// The PKCS#8 private key may be encrypted using a password.
@@ -156,7 +215,7 @@ namespace Opc.Ua.Security.Certificates
                     // Extract the base64-encoded section
                     string pemData = pemText.Substring(beginIndex, endIndex - beginIndex).Trim();
                     byte[] decodedBytes = new byte[pemData.Length];
-                    if(Convert.TryFromBase64Chars(pemData, decodedBytes, out int bytesDecoded))
+                    if (Convert.TryFromBase64Chars(pemData, decodedBytes, out int bytesDecoded))
                     {
                         // Resize array to actual decoded length
                         Array.Resize(ref decodedBytes, bytesDecoded);
@@ -203,8 +262,8 @@ namespace Opc.Ua.Security.Certificates
         }
 #endregion
 
-#region Private Methods
-#endregion
+        #region Private Methods
+        #endregion
     }
 }
 #endif

--- a/Libraries/Opc.Ua.Security.Certificates/PEM/PEMReader.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/PEM/PEMReader.cs
@@ -44,64 +44,6 @@ namespace Opc.Ua.Security.Certificates
     {
         #region Public Methods
         /// <summary>
-        /// Import multiple X509 certificates from PEM data.
-        /// Supports a maximum of 99 certificates in the PEM data.
-        /// </summary>
-        /// <param name="pemDataBlob">The PEM datablob as byte array.</param>
-        /// <returns>The certificates.</returns>
-        public static X509Certificate2Collection ImportX509CertificatesFromPEM(
-            ReadOnlySpan<byte> pemDataBlob)
-        {
-            var certificates = new X509Certificate2Collection();
-            string label = "CERTIFICATE";
-            try
-            {
-                string pemText = Encoding.UTF8.GetString(pemDataBlob);
-                int count = 0;
-                int endIndex = 0;
-                while (endIndex > -1 && count < 99)
-                {
-                    count++;
-                    string beginlabel = $"-----BEGIN {label}-----";
-                    int beginIndex = pemText.IndexOf(beginlabel, StringComparison.Ordinal);
-                    if (beginIndex < 0)
-                    {
-                        return certificates;
-                    }
-                    string endlabel = $"-----END {label}-----";
-                    endIndex = pemText.IndexOf(endlabel, StringComparison.Ordinal);
-                    beginIndex += beginlabel.Length;
-                    if (endIndex < 0 || endIndex <= beginIndex)
-                    {
-                        return certificates;
-                    }
-                    var pemCertificateContent = pemText.Substring(beginIndex, endIndex - beginIndex);
-                    Span<byte> pemCertificateDecoded = new Span<byte>(new byte[pemCertificateContent.Length]);
-                    if (Convert.TryFromBase64Chars(pemCertificateContent, pemCertificateDecoded, out var bytesWritten))
-                    {
-#if NET6_0_OR_GREATER
-                        certificates.Add(X509CertificateLoader.LoadCertificate(pemCertificateDecoded));
-#else
-                        certificates.Add(new X509Certificate2(pemCertificateDecoded.ToArray()));
-#endif
-                    }
-
-                    pemText = pemText.Substring(endIndex + endlabel.Length);
-                }
-            }
-            catch (CryptographicException)
-            {
-                throw;
-            }
-            catch (Exception ex)
-            {
-                throw new CryptographicException("Failed to decode the PEM encoded Certificates.", ex);
-            }
-            return certificates;
-        }
-
-
-        /// <summary>
         /// Import a PKCS#8 private key or RSA private key from PEM.
         /// The PKCS#8 private key may be encrypted using a password.
         /// </summary>

--- a/Libraries/Opc.Ua.Security.Certificates/PEM/PEMReader.cs
+++ b/Libraries/Opc.Ua.Security.Certificates/PEM/PEMReader.cs
@@ -33,7 +33,6 @@ using System;
 using System.Security.Cryptography;
 using System.IO;
 using System.Text;
-using System.Security.Cryptography.X509Certificates;
 
 namespace Opc.Ua.Security.Certificates
 {

--- a/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
+++ b/Stack/Opc.Ua.Core/Security/Certificates/DirectoryCertificateStore.cs
@@ -37,7 +37,6 @@ namespace Opc.Ua
         private const string kPemExtension = ".pem";
         private const string kPfxExtension = ".pfx";
         private const string kCertSearchString = "*.der";
-        private const string kPemCertSearchString = "*.pem";
 
         #region Constructors
         /// <summary>


### PR DESCRIPTION
## Proposed changes

Implement PEMReader for multiple Certificates contained in PEM files.
Read out content of PEM file in directory certificate store

TODO: 
- Create separate Certificate files.
- Handle private Keys
- Support old Platforms
- Add Tests


## Related Issues

- Fixes #

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/CONTRIBUTING.md) doc.
- [ ] I have signed the [CLA](https://opcfoundation.org/license/cla/ContributorLicenseAgreementv1.0.pdf).
- [ ] I ran tests locally with my changes, all passed.
- [ ] I fixed all failing tests in the CI pipelines. 
- [ ] I fixed all introduced issues with CodeQL and LGTM.
- [ ] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
